### PR TITLE
better Model.save() compatibility for CommonInfo.save()

### DIFF
--- a/ambient_toolbox/models.py
+++ b/ambient_toolbox/models.py
@@ -12,14 +12,14 @@ class CreatedAtInfo(models.Model):
     class Meta:
         abstract = True
 
-    def save(self, *args, **kwargs):
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         # just a fallback for old data
         if not self.created_at:
             self.created_at = now()
-        super().save(*args, **kwargs)
+        super().save(force_insert, force_update, using, update_fields)
 
 
-class CommonInfo(CreatedAtInfo, models.Model):
+class CommonInfo(CreatedAtInfo):
     # Automatically add the model's fields to the 'update_fields' list if specified on save()
     ALWAYS_UPDATE_FIELDS = True
 
@@ -44,16 +44,16 @@ class CommonInfo(CreatedAtInfo, models.Model):
     class Meta:
         abstract = True
 
-    def save(self, *args, **kwargs):
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.lastmodified_at = now()
         current_user = self.get_current_user()
         self.set_user_fields(current_user)
 
         # Handle case that somebody only wants to update some fields
-        if 'update_fields' in kwargs and self.ALWAYS_UPDATE_FIELDS:
-            kwargs['update_fields'] += ('lastmodified_at', 'lastmodified_by', 'created_at', 'created_by')
+        if update_fields is not None and self.ALWAYS_UPDATE_FIELDS:
+            update_fields = {'lastmodified_at', 'lastmodified_by', 'created_at', 'created_by'}.update(*update_fields)
 
-        super().save(*args, **kwargs)
+        super().save(force_insert, force_update, using, update_fields)
 
     @staticmethod
     def get_current_user():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,7 +13,15 @@ class CommonInfoTest(TestCase):
         with freeze_time('2020-09-19'):
             obj = CommonInfoBasedModel.objects.create(value=1)
         obj.value = 2
-        obj.save(update_fields=('value',))
+
+        # Django's Model.save() can be called with positional args, so we should support this as well.
+        args = (
+            False,  # default for force_insert
+            False,  # default for force_update
+            None,  # default for using
+            (x for x in ['value']),  # update_fields is supposed to accept any Iterable[str]
+        )
+        obj.save(*args)
 
         obj.refresh_from_db()
         self.assertEqual(obj.value, 2)


### PR DESCRIPTION
Stumbled upon this when migrating our project from `ai_django_core==5.14.1` to `ambient_toolbox==8.4.0`. We had some code passing a set to a model's save method, eg. `obj.save(update_fields={"license_plate"})`. This used to work before, and is also in line with the corresponding [Django docs](https://docs.djangoproject.com/en/4.2/ref/models/instances/#specifying-which-fields-to-save:~:text=any%20iterable%20containing%20strings), allowing `update_fields` to be any iterable containing strings.

Would be great if we could add this, our CommonInfo would then behave more closely to its base class in certain situations.