### PR TITLE
Model.save() compatibility revisited

### DIFF
--- a/ambient_toolbox/models.py
+++ b/ambient_toolbox/models.py
@@ -12,11 +12,17 @@ class CreatedAtInfo(models.Model):
     class Meta:
         abstract = True
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None, **kwargs):
         # just a fallback for old data
         if not self.created_at:
             self.created_at = now()
-        super().save(force_insert, force_update, using, update_fields)
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+            **kwargs,
+        )
 
 
 class CommonInfo(CreatedAtInfo):
@@ -44,7 +50,7 @@ class CommonInfo(CreatedAtInfo):
     class Meta:
         abstract = True
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None, **kwargs):
         self.lastmodified_at = now()
         current_user = self.get_current_user()
         self.set_user_fields(current_user)
@@ -53,7 +59,13 @@ class CommonInfo(CreatedAtInfo):
         if update_fields is not None and self.ALWAYS_UPDATE_FIELDS:
             update_fields = {'lastmodified_at', 'lastmodified_by', 'created_at', 'created_by'}.union(update_fields)
 
-        super().save(force_insert, force_update, using, update_fields)
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+            **kwargs,
+        )
 
     @staticmethod
     def get_current_user():

--- a/ambient_toolbox/models.py
+++ b/ambient_toolbox/models.py
@@ -51,7 +51,7 @@ class CommonInfo(CreatedAtInfo):
 
         # Handle case that somebody only wants to update some fields
         if update_fields is not None and self.ALWAYS_UPDATE_FIELDS:
-            update_fields = {'lastmodified_at', 'lastmodified_by', 'created_at', 'created_by'}.update(*update_fields)
+            update_fields = {'lastmodified_at', 'lastmodified_by', 'created_at', 'created_by'}.union(update_fields)
 
         super().save(force_insert, force_update, using, update_fields)
 

--- a/testapp/migrations/0001_initial.py
+++ b/testapp/migrations/0001_initial.py
@@ -123,6 +123,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ('value', models.PositiveIntegerField(default=0)),
+                ('value_b', models.PositiveIntegerField(default=0)),
                 (
                     'created_by',
                     models.ForeignKey(

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -58,6 +58,7 @@ def send_email(sender, instance, **kwargs):
 
 class CommonInfoBasedModel(CommonInfo):
     value = models.PositiveIntegerField(default=0)
+    value_b = models.PositiveIntegerField(default=0)
 
     def __str__(self):
         return str(self.value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,8 +11,9 @@ class CommonInfoTest(TestCase):
     @freeze_time('2022-06-26 10:00')
     def test_save_update_fields_common_fields_set(self):
         with freeze_time('2020-09-19'):
-            obj = CommonInfoBasedModel.objects.create(value=1)
+            obj = CommonInfoBasedModel.objects.create(value=1, value_b=1)
         obj.value = 2
+        obj.value_b = 999
 
         # Django's Model.save() can be called with positional args, so we should support this as well.
         args = (
@@ -25,6 +26,7 @@ class CommonInfoTest(TestCase):
 
         obj.refresh_from_db()
         self.assertEqual(obj.value, 2)
+        self.assertEqual(obj.value_b, 1, "value_b should not have changed")
         self.assertEqual(obj.lastmodified_at, datetime.datetime(2022, 6, 26, 10))
 
     @patch('testapp.models.CommonInfoBasedModel.ALWAYS_UPDATE_FIELDS', new_callable=PropertyMock)


### PR DESCRIPTION
First of all, I broke the behavior of `update_fields` in v8.4.1 🙈 - this PR includes a corresponding test and fix.

---

Besides that, I noticed that we run into problems when a model inherits both from `django-safedelete`'s `SafeDeleteModel`  and our `CommonInfo` because `SafeDeleteModel.save` has an incompatible signature. FYI, here's an excerpt from their implementation:

```python
class SafeDeleteModel(models.Model):
    def save(self, keep_deleted=False, **kwargs):
        # ...
        super(SafeDeleteModel, self).save(**kwargs)
        # ...

# for comparison, this is from Django's models.Model:
class Model(...):
    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
        ...
```

This PR also includes a fix for that, by always passing params as kwargs to `super()`, and also allowing for excess kwargs.

I also tested these changes in our project, and they fix all test failures that currently occur when having `ambient_toolbox==8.4.1` installed.