### PR TITLE
Hard-fail if improper settings are detected

### DIFF
--- a/ambient_toolbox/services/custom_scrubber.py
+++ b/ambient_toolbox/services/custom_scrubber.py
@@ -8,6 +8,10 @@ from django.core.management import call_command
 from django.db import connections
 
 
+class ScrubbingError(RuntimeError):
+    pass
+
+
 class AbstractScrubbingService:
     DEFAULT_USER_PASSWORD = 'Admin0404!'
 
@@ -44,7 +48,7 @@ class AbstractScrubbingService:
         self._logger.info('Validating setup...')
         if not self._validation():
             self._logger.warning('Aborting process!')
-            return False
+            raise ScrubbingError('Scrubber Settings validation failed')
 
         # Custom pre-scrubbing
         for name in self.pre_scrub_functions:

--- a/ambient_toolbox/services/custom_scrubber.py
+++ b/ambient_toolbox/services/custom_scrubber.py
@@ -48,7 +48,7 @@ class AbstractScrubbingService:
         self._logger.info('Validating setup...')
         if not self._validation():
             self._logger.warning('Aborting process!')
-            raise ScrubbingError('Scrubber Settings validation failed')
+            raise ScrubbingError('Scrubber settings validation failed')
 
         # Custom pre-scrubbing
         for name in self.pre_scrub_functions:


### PR DESCRIPTION
returning False doesn't break any surrounding processes (the command still exits with code 0)

Raise an Exception to make sure a process calling this will either fail or handle the Exception properly