### PR TITLE
Use of return value from django email backend

### DIFF
--- a/ambient_toolbox/mail/backends/whitelist_smtp.py
+++ b/ambient_toolbox/mail/backends/whitelist_smtp.py
@@ -74,4 +74,4 @@ class WhitelistEmailBackend(SMTPEmailBackend):
         Uses regular smtp-sending afterwards.
         """
         email_messages = self._process_recipients(email_messages)
-        super().send_messages(email_messages)
+        return super().send_messages(email_messages)


### PR DESCRIPTION
I think we should use the return value of the `send_messages` method so that we don't deviate from the django documentation when using the EmailMessage class.