### PR TITLE
Update translations.md

### DIFF
--- a/docs/features/translations.md
+++ b/docs/features/translations.md
@@ -8,7 +8,7 @@ time-stamped and the location comments can change very easily.
 
 Therefore, we've created the management command `create_translation_file`, which will help you as follows:
 
-> python manage.py create_translation_file --lang en
+> `python manage.py create_translation_file --lang en`
 
 * The management command will call `makemessages` with --no-location to avoid cluttering your `*.po` files with
   easy-to-cause merge conflict reasons


### PR DESCRIPTION
Makes the command visible in docs. It looked like this before, which made the "default" command which you should not use anymore more visible than the "new" one:
![image](https://github.com/ambient-innovation/ambient-toolbox/assets/6870808/4af0b643-085a-430f-bdbb-3687f9c0c768)
