### PR TITLE
Bugfix: Correct calendar week date calculation logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**11.7.1** (2025-01-17)
+  * Fixed bug in `get_start_and_end_date_from_calendar_week` leading to the first calendar week being determined incorrectly
+
 **11.7.0** (2025-01-16)
   * Added `GetOrNoneManagerMixin` manager mixin to provide `get_or_none()`
 

--- a/ambient_toolbox/__init__.py
+++ b/ambient_toolbox/__init__.py
@@ -1,3 +1,3 @@
 """Python toolbox of Ambient Digital containing an abundance of useful tools and gadgets."""
 
-__version__ = "11.7.0"
+__version__ = "11.7.1"

--- a/ambient_toolbox/utils/date.py
+++ b/ambient_toolbox/utils/date.py
@@ -102,11 +102,8 @@ def get_start_and_end_date_from_calendar_week(year: int, calendar_week: int) -> 
     # (0 = Monday, 6 = Sunday)
     weekday = first_day_of_year.weekday()
 
-    # monday = 0, sunday = 6
-    thursday = 3
-
     # Calculate the adjustment to find the Monday closest to the first day of the year
-    if weekday <= thursday:
+    if weekday <= calendar.THURSDAY:
         # If the day is Monday to Thursday (inclusive) move backward to reach the nearest Monday
         adjustment = -weekday
     else:

--- a/ambient_toolbox/utils/date.py
+++ b/ambient_toolbox/utils/date.py
@@ -92,21 +92,32 @@ def datetime_format(target_datetime: datetime.datetime, dt_format: str) -> str:
 
 def get_start_and_end_date_from_calendar_week(year: int, calendar_week: int) -> (datetime.date, datetime.date):
     """
-    Returns the first and last day of a given calendar week
+    Determines the start and end dates of a specific calendar week in a given year.
     """
-    start_of_week = datetime.datetime.strptime(f"{year}-{calendar_week}-1", "%Y-%W-%w").astimezone().date()
 
-    if calendar_week == 1:
-        # Calculating first_day_of_week for calendar_week == 1 is always tricky, as the first calendar week
-        # can actually start in the n-1 year. The above .strptime() can not handle this however, and would always
-        # return the first of January.
-        # For this case, we consider the fourth of january, as it will _always_ be in the first calendar week
-        # (see: https://en.wikipedia.org/wiki/ISO_week_date#First_week)
+    # Create a date object for the first day of the given year
+    first_day_of_year = datetime.date(year=year, month=1, day=1)
 
-        fourth_of_january = datetime.date(year=year, month=1, day=4)
+    # Determine which day of the week the first day of the year falls on
+    # (0 = Monday, 6 = Sunday)
+    weekday = first_day_of_year.weekday()
 
-        start_of_week = fourth_of_january - relativedelta(days=fourth_of_january.weekday())
+    # Calculate the adjustment to find the Monday closest to the first day of the year
+    if weekday <= 3:
+        # If the day is Monday to Thursday (inclusive) move backward to reach the nearest Monday
+        adjustment = -weekday
+    else:
+        # If the day is Friday, Saturday, or Sunday move forward to reach the next Monday
+        adjustment = 7 - weekday
 
+    # Calculate the date of the closest (or same) Monday
+    closest_monday = first_day_of_year + datetime.timedelta(days=adjustment)
+
+    # Calculate the start of the requested calendar week
+    # (adjusting the closest Monday by the number of weeks required)
+    start_of_week = closest_monday + relativedelta(weeks=calendar_week - 1)
+
+    # Return the start date of the week and the date 6 days later (end of the week)
     return start_of_week, start_of_week + relativedelta(days=6)
 
 

--- a/ambient_toolbox/utils/date.py
+++ b/ambient_toolbox/utils/date.py
@@ -103,7 +103,7 @@ def get_start_and_end_date_from_calendar_week(year: int, calendar_week: int) -> 
     weekday = first_day_of_year.weekday()
 
     # Calculate the adjustment to find the Monday closest to the first day of the year
-    if weekday <= 3:
+    if weekday <= calendar.Day.THURSDAY:
         # If the day is Monday to Thursday (inclusive) move backward to reach the nearest Monday
         adjustment = -weekday
     else:

--- a/ambient_toolbox/utils/date.py
+++ b/ambient_toolbox/utils/date.py
@@ -102,8 +102,11 @@ def get_start_and_end_date_from_calendar_week(year: int, calendar_week: int) -> 
     # (0 = Monday, 6 = Sunday)
     weekday = first_day_of_year.weekday()
 
+    # monday = 0, sunday = 6
+    thursday = 3
+
     # Calculate the adjustment to find the Monday closest to the first day of the year
-    if weekday <= calendar.Day.THURSDAY:
+    if weekday <= thursday:
         # If the day is Monday to Thursday (inclusive) move backward to reach the nearest Monday
         adjustment = -weekday
     else:

--- a/tests/test_utils_date.py
+++ b/tests/test_utils_date.py
@@ -46,6 +46,14 @@ class DateUtilTest(TestCase):
         self.assertEqual(monday, datetime.date(year=2017, month=7, day=24))
         self.assertEqual(sunday, datetime.date(year=2017, month=7, day=30))
 
+        monday, sunday = get_start_and_end_date_from_calendar_week(2025, 3)
+        self.assertEqual(monday, datetime.date(year=2025, month=1, day=13))
+        self.assertEqual(sunday, datetime.date(year=2025, month=1, day=19))
+
+        monday, sunday = get_start_and_end_date_from_calendar_week(2026, 3)
+        self.assertEqual(monday, datetime.date(year=2026, month=1, day=12))
+        self.assertEqual(sunday, datetime.date(year=2026, month=1, day=18))
+
     def test_get_next_calendar_week_any_week(self):
         self.assertEqual(get_next_calendar_week(datetime.date(year=2020, month=9, day=19)), 39)
 


### PR DESCRIPTION
Fixes a bug in `get_start_and_end_date_from_calendar_week` where the first calendar week was incorrectly determined. Adjusted the logic to compute the correct week start date based on ISO week rules. Added comprehensive test cases to ensure proper functionality for edge cases.

Bärbel and I stumbled upon this 🫠🫠🫠