### PR TITLE
Refactor: Rename "White-XY" to "Allow-XY" and "Black-XY" to "Block-XY"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**12.1.6** (2025-05-17)
+  * Refactor all "white-XY" related code to "allow-XY"
+  * Introduce deprecation warnings for all "white-XY" terms
+
 **12.1.5** (2025-04-03)
   * Maintenance updates via ambient-package-update
   * Improved some conditions in permission fixtures feature

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 **12.1.6** (2025-05-17)
   * Refactor all "white-XY" related code to "allow-XY"
+  * Refactor all "black-XY" related code to "block-XY"
   * Introduce deprecation warnings for all "white-XY" terms
 
 **12.1.5** (2025-04-03)

--- a/ambient_toolbox/mail/backends/allowlist_smtp.py
+++ b/ambient_toolbox/mail/backends/allowlist_smtp.py
@@ -27,7 +27,7 @@ class AllowlistEmailBackend(SMTPEmailBackend):
         Until then, keep this for backwards compatibility but warn users about future deprecation.
         """
         warnings.warn(
-            "get_domain_whitelist() is deprecated. Use get_domain_allowlist() instead.",
+            "get_domain_whitelist() is deprecated and will be removed in a future version. Use get_domain_allowlist() instead.",
             category=DeprecationWarning,
             stacklevel=1,
         )
@@ -40,7 +40,7 @@ class AllowlistEmailBackend(SMTPEmailBackend):
         Until then, keep this for backwards compatibility but warn users about future deprecation.
         """
         warnings.warn(
-            "whitify_mail_addresses() is deprecated. Use allowify_mail_addresses() instead.",
+            "whitify_mail_addresses() is deprecated and will be removed in a future version. Use allowify_mail_addresses() instead.",
             category=DeprecationWarning,
             stacklevel=1,
         )

--- a/ambient_toolbox/mail/backends/allowlist_smtp.py
+++ b/ambient_toolbox/mail/backends/allowlist_smtp.py
@@ -1,0 +1,108 @@
+import re
+import warnings
+
+from django.conf import settings
+from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
+
+
+class AllowlistEmailBackend(SMTPEmailBackend):
+    """
+    Via the following settings it is possible to configure if mails are sent to all domains.
+    If not, you can configure a redirect to an inbox via CATCHALL.
+
+    EMAIL_BACKEND = 'ambient_toolbox.mail.backends.allowlist_smtp.AllowlistEmailBackend'
+    EMAIL_BACKEND_DOMAIN_ALLOWLIST = ['ambient.digital']
+    EMAIL_BACKEND_REDIRECT_ADDRESS = '%s@testuser.ambient.digital'
+
+    If `EMAIL_BACKEND_REDIRECT_ADDRESS` is set, a mail to `john.doe@example.com` will be redirected to
+    `john.doe_example.com@testuser.ambient.digital`
+    """
+
+    # --------------------- deprecated methods START
+
+    @staticmethod
+    def get_domain_whitelist() -> list:
+        """
+        The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+        Until then, keep this for backwards compatibility but warn users about future deprecation.
+        """
+        warnings.warn(
+            "get_domain_whitelist() is deprecated. Use get_domain_allowlist() instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+        return AllowlistEmailBackend.get_domain_allowlist()
+
+    @staticmethod
+    def whitify_mail_addresses(mail_address_list: list) -> list:
+        """
+        The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+        Until then, keep this for backwards compatibility but warn users about future deprecation.
+        """
+        warnings.warn(
+            "whitify_mail_addresses() is deprecated. Use allowify_mail_addresses() instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+        return AllowlistEmailBackend.allowify_mail_addresses(mail_address_list=mail_address_list)
+
+    # --------------------- deprecated methods END
+
+    @staticmethod
+    def get_domain_allowlist() -> list:
+        """
+        Getter for configuration variable from the settings.
+        Will return a list of domains: ['ambient.digital', 'ambient.digital']
+        """
+        return getattr(settings, "EMAIL_BACKEND_DOMAIN_ALLOWLIST", [])
+
+    @staticmethod
+    def get_email_regex():
+        """
+        Getter for configuration variable from the settings.
+        Will return a RegEX to match email allowlisted domains.
+        """
+        return r"^[\w\-\.]+@(%s)$" % "|".join(x for x in AllowlistEmailBackend.get_domain_allowlist()).replace(
+            ".", r"\."
+        )
+
+    @staticmethod
+    def get_backend_redirect_address() -> str:
+        """
+        Getter for configuration variable from the settings.
+        Will return a string with a placeholder for redirecting non-allowlisted domains.
+        """
+        return settings.EMAIL_BACKEND_REDIRECT_ADDRESS
+
+    @staticmethod
+    def allowify_mail_addresses(mail_address_list: list) -> list:
+        """
+        Check for every recipient in the list if its domain is included in the allowlist.
+        If not, and we have a redirect address configured, we change the original mail address to something new,
+        according to our configuration.
+        """
+        allowed_recipients = []
+        for to in mail_address_list:
+            if re.search(AllowlistEmailBackend.get_email_regex(), to):
+                allowed_recipients.append(to)
+            elif AllowlistEmailBackend.get_backend_redirect_address():
+                # Send not allowed emails to the configured redirect address (with CATCHALL)
+                allowed_recipients.append(AllowlistEmailBackend.get_backend_redirect_address() % to.replace("@", "_"))
+        return allowed_recipients
+
+    def _process_recipients(self, email_messages):
+        """
+        Helper method to wrap custom logic of this backend. Required to make it testable.
+        """
+        for email in email_messages:
+            allowed_recipients = self.allowify_mail_addresses(email.to)
+            email.to = allowed_recipients
+        return email_messages
+
+    def send_messages(self, email_messages):
+        """
+        Checks if email-recipients are in allowed domains and cancels if not.
+        Uses regular smtp-sending afterward.
+        """
+        email_messages = self._process_recipients(email_messages)
+        return super().send_messages(email_messages)

--- a/ambient_toolbox/mail/backends/whitelist_smtp.py
+++ b/ambient_toolbox/mail/backends/whitelist_smtp.py
@@ -1,77 +1,19 @@
-import re
-
-from django.conf import settings
-from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
+import warnings
 
 
-class WhitelistEmailBackend(SMTPEmailBackend):
+from ambient_toolbox.mail.backends.allowlist_smtp import AllowlistEmailBackend
+
+
+class WhitelistEmailBackend(AllowlistEmailBackend):
     """
-    Via the following settings it is possible to configure if mails are sent to all domains.
-    If not, you can configure a redirect to an inbox via CATCHALL.
-
-    EMAIL_BACKEND = 'ambient_toolbox.mail.backends.whitelist_smtp.WhitelistEmailBackend'
-    EMAIL_BACKEND_DOMAIN_WHITELIST = ['ambient.digital']
-    EMAIL_BACKEND_REDIRECT_ADDRESS = '%s@testuser.ambient.digital'
-
-    If `EMAIL_BACKEND_REDIRECT_ADDRESS` is set, a mail to `john.doe@example.com` will be redirected to
-    `john.doe_example.com@testuser.ambient.digital`
+    The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+    Until then, keep this for backwards compatibility but warn users about future deprecation.
     """
 
-    @staticmethod
-    def get_domain_whitelist() -> list:
-        """
-        Getter for configuration variable from the settings.
-        Will return a list of domains: ['ambient.digital', 'ambient.digital']
-        """
-        return getattr(settings, "EMAIL_BACKEND_DOMAIN_WHITELIST", [])
-
-    @staticmethod
-    def get_email_regex():
-        """
-        Getter for configuration variable from the settings.
-        Will return a RegEX to match email whitelisted domains.
-        """
-        return r"^[\w\-\.]+@(%s)$" % "|".join(x for x in WhitelistEmailBackend.get_domain_whitelist()).replace(
-            ".", r"\."
+    def __init__(self, fail_silently=False, **kwargs):
+        warnings.warn(
+            "WhitelistEmailBackend is deprecated. Use AllowlistEmailBackend instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
         )
-
-    @staticmethod
-    def get_backend_redirect_address() -> str:
-        """
-        Getter for configuration variable from the settings.
-        Will return a string with a placeholder for redirecting non-whitelisted domains.
-        """
-        return settings.EMAIL_BACKEND_REDIRECT_ADDRESS
-
-    @staticmethod
-    def whitify_mail_addresses(mail_address_list: list) -> list:
-        """
-        Check for every recipient in the list if its domain is included in the whitelist.
-        If not, and we have a redirect address configured, we change the original mail address to something new,
-        according to our configuration.
-        """
-        allowed_recipients = []
-        for to in mail_address_list:
-            if re.search(WhitelistEmailBackend.get_email_regex(), to):
-                allowed_recipients.append(to)
-            elif WhitelistEmailBackend.get_backend_redirect_address():
-                # Send not allowed emails to the configured redirect address (with CATCHALL)
-                allowed_recipients.append(WhitelistEmailBackend.get_backend_redirect_address() % to.replace("@", "_"))
-        return allowed_recipients
-
-    def _process_recipients(self, email_messages):
-        """
-        Helper method to wrap custom logic of this backend. Required to make it testable.
-        """
-        for email in email_messages:
-            allowed_recipients = self.whitify_mail_addresses(email.to)
-            email.to = allowed_recipients
-        return email_messages
-
-    def send_messages(self, email_messages):
-        """
-        Checks if email-recipients are in allowed domains and cancels if not.
-        Uses regular smtp-sending afterward.
-        """
-        email_messages = self._process_recipients(email_messages)
-        return super().send_messages(email_messages)
+        super().__init__(fail_silently, **kwargs)

--- a/ambient_toolbox/mail/backends/whitelist_smtp.py
+++ b/ambient_toolbox/mail/backends/whitelist_smtp.py
@@ -12,7 +12,7 @@ class WhitelistEmailBackend(AllowlistEmailBackend):
 
     def __init__(self, fail_silently=False, **kwargs):
         warnings.warn(
-            "WhitelistEmailBackend is deprecated. Use AllowlistEmailBackend instead.",
+            "WhitelistEmailBackend is deprecated and will be removed in a future version. Use AllowlistEmailBackend instead.",
             category=DeprecationWarning,
             stacklevel=1,
         )

--- a/ambient_toolbox/middleware/current_user.py
+++ b/ambient_toolbox/middleware/current_user.py
@@ -21,7 +21,7 @@ class CurrentUserMiddleware(CurrentRequestMiddleware):
 
     def __init__(self, get_response: Callable[["HttpRequest"], "HttpResponse"]):
         warnings.warn(
-            "CurrentUserMiddleware is deprecated. Use CurrentRequestMiddleware instead.",
+            "CurrentUserMiddleware is deprecated and will be removed in a future version. Use CurrentRequestMiddleware instead.",
             category=DeprecationWarning,
             stacklevel=1,
         )

--- a/ambient_toolbox/tests/structure_validator/settings.py
+++ b/ambient_toolbox/tests/structure_validator/settings.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 # Test validator
-TEST_STRUCTURE_VALIDATOR_FILE_WHITELIST = []
+TEST_STRUCTURE_VALIDATOR_FILE_ALLOWLIST = []
 try:
     TEST_STRUCTURE_VALIDATOR_BASE_DIR = settings.BASE_DIR
 except AttributeError:

--- a/ambient_toolbox/tests/structure_validator/test_structure_validator.py
+++ b/ambient_toolbox/tests/structure_validator/test_structure_validator.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from pathlib import Path
 from typing import Union
 
@@ -9,20 +10,69 @@ from ambient_toolbox.tests.structure_validator import settings as toolbox_settin
 
 
 class StructureTestValidator:
-    file_whitelist: list
+    _file_whitelist: list
+
+    file_allowlist: list
     issue_list: list
 
     def __init__(self):
-        self.file_whitelist = self._get_file_whitelist()
+        self._file_whitelist = self._get_file_allowlist()
+
+        self.file_allowlist = self._get_file_allowlist()
         self.issue_list = []
+
+    # --------------------- deprecated methods START
+
+    @property
+    def file_whitelist(self):
+        """
+        The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+        Until then, keep this for backwards compatibility but warn users about future deprecation.
+        """
+
+        warnings.warn(
+            "The 'file_whitelist' attribute is deprecated and will be removed in a future version. Use 'file_allowlist' instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+        return self._file_whitelist
+
+    @file_whitelist.setter
+    def file_whitelist(self, value):
+        """
+        The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+        Until then, keep this for backwards compatibility but warn users about future deprecation.
+        """
+
+        warnings.warn(
+            "The 'file_whitelist' attribute is deprecated and will be removed in a future version. Use 'file_allowlist' instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+        self._file_whitelist = value
 
     @staticmethod
     def _get_file_whitelist() -> list:
-        default_whitelist = ["__init__"]
+        """
+        The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+        Until then, keep this for backwards compatibility but warn users about future deprecation.
+        """
+        warnings.warn(
+            "_get_file_whitelist() is deprecated and will be removed in a future version. Use _get_file_allowlist() instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+        return StructureTestValidator._get_file_allowlist()
+
+    # --------------------- deprecated methods END
+
+    @staticmethod
+    def _get_file_allowlist() -> list:
+        default_allowlist = ["__init__"]
         try:
-            return default_whitelist + settings.TEST_STRUCTURE_VALIDATOR_FILE_WHITELIST
+            return default_allowlist + settings.TEST_STRUCTURE_VALIDATOR_FILE_ALLOWLIST
         except AttributeError:
-            return default_whitelist + toolbox_settings.TEST_STRUCTURE_VALIDATOR_FILE_WHITELIST
+            return default_allowlist + toolbox_settings.TEST_STRUCTURE_VALIDATOR_FILE_ALLOWLIST
 
     @staticmethod
     def _get_base_dir() -> Union[Path, str]:
@@ -54,7 +104,7 @@ class StructureTestValidator:
             return toolbox_settings.TEST_STRUCTURE_VALIDATOR_APP_LIST
 
     def _check_missing_test_prefix(self, *, root: str, file: str, filename: str, extension: str) -> bool:
-        if extension == ".py" and not filename[0:5] == "test_" and filename not in self.file_whitelist:
+        if extension == ".py" and not filename[0:5] == "test_" and filename not in self.file_allowlist:
             file_path = f"{root}\\{file}".replace("\\", "/")
             self.issue_list.append(f'Python file without "test_" prefix found: {file_path!r}.')
             return False

--- a/ambient_toolbox/utils/model.py
+++ b/ambient_toolbox/utils/model.py
@@ -1,19 +1,28 @@
+import warnings
 from typing import Optional
 
 from django.db.models import ForeignKey, Model
 
 
-def object_to_dict(obj, blacklisted_fields: Optional[list] = None, include_id: bool = False) -> dict:
+def object_to_dict(obj, blacklisted_fields: Optional[list] = None, blocklisted_fields: Optional[list] = None, include_id: bool = False) -> dict:
     """
     Returns a dict with all data defined in the model class as a key-value-dict
     Attention: Does not work for M2M fields!
     """
-    # Default blacklist
-    blacklisted_fields = blacklisted_fields if blacklisted_fields else []
+    # Default blocklist
+    blocklisted_fields = blocklisted_fields if blocklisted_fields else []
 
-    # Add default django primary key to blacklist
+    if blacklisted_fields:
+        warnings.warn(
+            "blacklisted_fields is deprecated and will be removed in a future version. Use blocklisted_fields instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+        blocklisted_fields += blacklisted_fields
+
+    # Add default django primary key to blocklist
     if not include_id:
-        blacklisted_fields.append("id")
+        blocklisted_fields.append("id")
 
     data = vars(obj)
 
@@ -24,7 +33,7 @@ def object_to_dict(obj, blacklisted_fields: Optional[list] = None, include_id: b
         else:
             valid_fields.append(f"{f.name}_id")
 
-    valid_data = {key: value for key, value in data.items() if key in valid_fields and key not in blacklisted_fields}
+    valid_data = {key: value for key, value in data.items() if key in valid_fields and key not in blocklisted_fields}
 
     return valid_data
 

--- a/docs/features/mail.md
+++ b/docs/features/mail.md
@@ -2,7 +2,7 @@
 
 ## Backends
 
-### WhitelistEmailBackend
+### AllowlistEmailBackend
 
 In some cases it is useful to debug and test email functionality on local or test environments. Additionally, your
 project could contain logic, that triggers emails in the background, so it is very important, that you don't send emails
@@ -14,8 +14,8 @@ define an email address (must be a catchall inbox), where the restricted emails 
 Example:
 
 ```python
-EMAIL_BACKEND = "ambient_toolbox.mail.backends.whitelist_smtp.WhitelistEmailBackend"
-EMAIL_BACKEND_DOMAIN_WHITELIST = ["ambient.digital"]
+EMAIL_BACKEND = "ambient_toolbox.mail.backends.allowlist_smtp.AllowlistEmailBackend"
+EMAIL_BACKEND_DOMAIN_ALLOWLIST = ["ambient.digital"]
 EMAIL_BACKEND_REDIRECT_ADDRESS = "%s@testuser.ambient.digital"
 ```
 

--- a/docs/features/tests.md
+++ b/docs/features/tests.md
@@ -115,7 +115,7 @@ You can define all of those settings variables in your main Django settings file
 
 | Variable                                        | Type | Default                 | Explanation                                                         |
 |-------------------------------------------------|------|-------------------------|---------------------------------------------------------------------|
-| TEST_STRUCTURE_VALIDATOR_FILE_WHITELIST         | list | []                      | Filenames which will be ignored, will always ignore `__init__`      |
+| TEST_STRUCTURE_VALIDATOR_FILE_ALLOWLIST         | list | []                      | Filenames which will be ignored, will always ignore `__init__`      |
 | TEST_STRUCTURE_VALIDATOR_BASE_DIR               | Path | settings.BASE_DIR       | Root path to your application (BASE_DIR in a vanilla Django setup)   |
 | TEST_STRUCTURE_VALIDATOR_BASE_APP_NAME          | str  | "apps"                  | Directory where all your Django apps live in, can be set to "".     |
 | TEST_STRUCTURE_VALIDATOR_APP_LIST               | list | settings.INSTALLED_APPS | List of all your Django apps you want to validate                   |

--- a/docs/features/utils/model.md
+++ b/docs/features/utils/model.md
@@ -2,9 +2,9 @@
 
 ## Model
 
-### Convert object to dictionary
+### Convert an object to dictionary
 
-The function ``object_to_dict(obj, blacklisted_fields, include_id)`` takes an instance of a django model and
+The function ``object_to_dict(obj, blocklisted_fields, include_id)`` takes an instance of a django model and
 extracts all attributes into a dictionary:
 
 ````python
@@ -20,7 +20,7 @@ result = object_to_dict(obj)
 # result = {'value_1': 19, 'value_2': 9}
 ````
 
-Optionally, fields can be excluded with the parameter ``blacklisted_fields``.
+Optionally, fields can be excluded with the parameter ``blocklisted_fields``.
 Passing a list of field names as string will prevent them from ending up in the result dictionary.
 
 ````python

--- a/settings.py
+++ b/settings.py
@@ -61,8 +61,42 @@ MIDDLEWARE = (
 )
 
 # Mail backend
-EMAIL_BACKEND_DOMAIN_WHITELIST = ""
 EMAIL_BACKEND_REDIRECT_ADDRESS = ""
+EMAIL_BACKEND_DOMAIN_ALLOWLIST = ""
+
+_EMAIL_BACKEND_DOMAIN_WHITELIST = ""
+@property
+def EMAIL_BACKEND_DOMAIN_WHITELIST():
+    """
+    The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+    Until then, keep this for backwards compatibility but warn users about future deprecation.
+    """
+
+    import warnings
+    warnings.warn(
+        "The 'EMAIL_BACKEND_DOMAIN_WHITELIST' setting is deprecated and will be removed in a future version. Use 'EMAIL_BACKEND_DOMAIN_ALLOWLIST' instead.",
+        category=DeprecationWarning,
+        stacklevel=1,
+    )
+    return _EMAIL_BACKEND_DOMAIN_WHITELIST
+
+
+@EMAIL_BACKEND_DOMAIN_WHITELIST.setter
+def EMAIL_BACKEND_DOMAIN_WHITELIST(value):
+    """
+    The term "Whitelist" will be deprecated in 12.2 and move to "Allowlist".
+    Until then, keep this for backwards compatibility but warn users about future deprecation.
+    """
+
+    import warnings
+    from django.conf import settings
+
+    warnings.warn(
+        "The 'EMAIL_BACKEND_DOMAIN_WHITELIST' setting is deprecated and will be removed in a future version. Use 'EMAIL_BACKEND_DOMAIN_ALLOWLIST' instead.",
+        category=DeprecationWarning,
+        stacklevel=1,
+    )
+    settings._EMAIL_BACKEND_DOMAIN_WHITELIST = value
 
 TIME_ZONE = "UTC"
 

--- a/tests/ambient_toolbox/test_test_structure_validator.py
+++ b/tests/ambient_toolbox/test_test_structure_validator.py
@@ -11,21 +11,21 @@ class TestStructureValidatorTest(TestCase):
     def test_init_regular(self):
         service = StructureTestValidator()
 
-        self.assertEqual(service.file_whitelist, ["__init__"])
+        self.assertEqual(service.file_allowlist, ["__init__"])
         self.assertEqual(service.issue_list, [])
 
-    @override_settings(TEST_STRUCTURE_VALIDATOR_FILE_WHITELIST=["my_file"])
-    def test_get_file_whitelist_from_settings(self):
+    @override_settings(TEST_STRUCTURE_VALIDATOR_FILE_ALLOWLIST=["my_file"])
+    def test_get_file_allowlist_from_settings(self):
         service = StructureTestValidator()
-        file_whitelist = service._get_file_whitelist()
+        file_allowlist = service._get_file_allowlist()
 
-        self.assertEqual(file_whitelist, ["__init__", "my_file"])
+        self.assertEqual(file_allowlist, ["__init__", "my_file"])
 
-    def test_get_file_whitelist_fallback(self):
+    def test_get_file_allowlist_fallback(self):
         service = StructureTestValidator()
-        file_whitelist = service._get_file_whitelist()
+        file_allowlist = service._get_file_allowlist()
 
-        self.assertEqual(file_whitelist, ["__init__"])
+        self.assertEqual(file_allowlist, ["__init__"])
 
     @override_settings(TEST_STRUCTURE_VALIDATOR_BASE_DIR=settings.BASE_PATH)
     def test_get_base_dir_from_settings(self):
@@ -91,8 +91,8 @@ class TestStructureValidatorTest(TestCase):
         self.assertTrue(result)
         self.assertEqual(len(service.issue_list), 0)
 
-    @override_settings(TEST_STRUCTURE_VALIDATOR_FILE_WHITELIST=["my_file"])
-    def test_check_missing_test_prefix_wrong_prefix_but_whitelisted(self):
+    @override_settings(TEST_STRUCTURE_VALIDATOR_FILE_ALLOWLIST=["my_file"])
+    def test_check_missing_test_prefix_wrong_prefix_but_allowlisted(self):
         service = StructureTestValidator()
         result = service._check_missing_test_prefix(
             root="root/path",

--- a/tests/test_utils_model.py
+++ b/tests/test_utils_model.py
@@ -10,15 +10,15 @@ class UtilModelTest(TestCase):
         obj = MySingleSignalModel.objects.create(value=17)
         self.assertEqual(object_to_dict(obj), {"value": obj.value})
 
-    def test_object_to_dict_blacklist(self):
+    def test_object_to_dict_blocklist(self):
         obj = MySingleSignalModel.objects.create(value=17)
         self.assertEqual(object_to_dict(obj, ["value"]), {})
 
-    def test_object_to_dict_with_id_with_blacklist(self):
+    def test_object_to_dict_with_id_with_blocklist(self):
         obj = MySingleSignalModel.objects.create(value=17)
         self.assertEqual(object_to_dict(obj, ["value"], True), {"id": obj.id})
 
-    def test_with_id_no_blacklist(self):
+    def test_with_id_no_blocklist(self):
         obj = MySingleSignalModel.objects.create(value=17)
         self.assertEqual(object_to_dict(obj, include_id=True), {"id": obj.id, "value": obj.value})
 

--- a/tests/tests/test_mail_backends.py
+++ b/tests/tests/test_mail_backends.py
@@ -4,35 +4,35 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.mail.backends.smtp import EmailBackend
 from django.test import TestCase, override_settings
 
-from ambient_toolbox.mail.backends.whitelist_smtp import WhitelistEmailBackend
+from ambient_toolbox.mail.backends.allowlist_smtp import AllowlistEmailBackend
 
 
 @override_settings(
-    EMAIL_BACKEND="ambient_toolbox.mail.backends.whitelist_smtp.WhitelistEmailBackend",
-    EMAIL_BACKEND_DOMAIN_WHITELIST=["valid.domain"],
+    EMAIL_BACKEND="ambient_toolbox.mail.backends.allowlist_smtp.AllowlistEmailBackend",
+    EMAIL_BACKEND_DOMAIN_ALLOWLIST=["valid.domain"],
     EMAIL_BACKEND_REDIRECT_ADDRESS="%s@testuser.valid.domain",
 )
-class MailBackendWhitelistBackendTest(TestCase):
-    def test_whitify_mail_addresses_replace(self):
+class MailBackendAllowlistBackendTest(TestCase):
+    def test_allowify_mail_addresses_replace(self):
         email_1 = "albertus.magnus@example.com"
         email_2 = "thomas_von_aquin@example.com"
-        processed_list = WhitelistEmailBackend.whitify_mail_addresses(mail_address_list=[email_1, email_2])
+        processed_list = AllowlistEmailBackend.allowify_mail_addresses(mail_address_list=[email_1, email_2])
 
         self.assertEqual(len(processed_list), 2)
         self.assertEqual(processed_list[0], "albertus.magnus_example.com@testuser.valid.domain")
         self.assertEqual(processed_list[1], "thomas_von_aquin_example.com@testuser.valid.domain")
 
-    def test_whitify_mail_addresses_whitelisted_domain(self):
+    def test_allowify_mail_addresses_allowlisted_domain(self):
         email = "platon@valid.domain"
-        processed_list = WhitelistEmailBackend.whitify_mail_addresses(mail_address_list=[email])
+        processed_list = AllowlistEmailBackend.allowify_mail_addresses(mail_address_list=[email])
 
         self.assertEqual(len(processed_list), 1)
         self.assertEqual(processed_list[0], email)
 
     @override_settings(EMAIL_BACKEND_REDIRECT_ADDRESS="")
-    def test_whitify_mail_addresses_no_redirect_configured(self):
+    def test_allowify_mail_addresses_no_redirect_configured(self):
         email = "sokrates@example.com"
-        processed_list = WhitelistEmailBackend.whitify_mail_addresses(mail_address_list=[email])
+        processed_list = AllowlistEmailBackend.allowify_mail_addresses(mail_address_list=[email])
 
         self.assertEqual(len(processed_list), 0)
 
@@ -41,22 +41,22 @@ class MailBackendWhitelistBackendTest(TestCase):
             "Test subject", "Here is the message.", "from@example.com", ["to@example.com"], connection=None
         )
 
-        backend = WhitelistEmailBackend()
+        backend = AllowlistEmailBackend()
         message_list = backend._process_recipients([mail])
         self.assertEqual(len(message_list), 1)
         self.assertEqual(message_list[0].to, ["to_example.com@testuser.valid.domain"])
 
     @mock.patch.object(EmailBackend, "send_messages")
-    @mock.patch.object(WhitelistEmailBackend, "_process_recipients")
+    @mock.patch.object(AllowlistEmailBackend, "_process_recipients")
     def test_send_messages_process_recipients_called(self, mocked_process_recipients, *args):
-        backend = WhitelistEmailBackend()
+        backend = AllowlistEmailBackend()
         backend.send_messages([])
 
         mocked_process_recipients.assert_called_once_with([])
 
     @mock.patch.object(EmailBackend, "send_messages")
     def test_send_messages_super_called(self, mocked_send_messages):
-        backend = WhitelistEmailBackend()
+        backend = AllowlistEmailBackend()
         backend.send_messages([])
 
         mocked_send_messages.assert_called_once_with([])


### PR DESCRIPTION
Hey @GitRon,

I stumbled upon the TEST_STRUCTURE_VALIDATOR_FILE_WHITELIST setting in my private project and took the liberty to refactor any "White-" and "Black-" occurrences to their modern counterparts :slightly_smiling_face: 

I've introduced a Deprecation Warning for all "old" names.

I'd suggest, that we remove all old variables / methods / etc in 12.2 (or 13?).

---

Let me know what you think :slightly_smiling_face: 