### PR TITLE
Write comprehensive tests for form and HTMX mixins

### DIFF
--- a/tests/view_layer/test_form_mixins.py
+++ b/tests/view_layer/test_form_mixins.py
@@ -1,0 +1,115 @@
+from django import forms
+from django.test import TestCase
+
+from ambient_toolbox.view_layer.form_mixins import CrispyLayoutFormMixin
+
+
+class DummyForm(forms.Form):
+    """Dummy form for testing."""
+
+    name = forms.CharField()
+
+
+class CrispyLayoutFormWithMixin(CrispyLayoutFormMixin, DummyForm):
+    """Form combining CrispyLayoutFormMixin with DummyForm."""
+
+
+class CrispyLayoutFormMixinTest(TestCase):
+    """Test suite for CrispyLayoutFormMixin with 100% branch coverage."""
+
+    def test_initializes_helper_attribute(self):
+        """Test that __init__ creates a FormHelper instance."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertIsNotNone(form.helper)
+        self.assertEqual(form.helper.__class__.__name__, "FormHelper")
+
+    def test_sets_form_class_attribute(self):
+        """Test that form_class is set to correct Bootstrap classes."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertEqual(form.helper.form_class, "form-horizontal form-bordered form-row-stripped")
+
+    def test_sets_form_method_attribute(self):
+        """Test that form_method is set to 'post'."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertEqual(form.helper.form_method, "post")
+
+    def test_adds_submit_button(self):
+        """Test that a submit button is added to the form."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertEqual(len(form.helper.inputs), 1)
+        submit_button = form.helper.inputs[0]
+        self.assertEqual(submit_button.field_classes, "btn btn-primary")
+        # The button should have name "submit_button"
+        self.assertEqual(submit_button.name, "submit_button")
+
+    def test_submit_button_has_correct_label(self):
+        """Test that submit button has 'Save' label (translated)."""
+        form = CrispyLayoutFormWithMixin()
+
+        submit_button = form.helper.inputs[0]
+        # The value should be a lazy translation object for "Save"
+        # We check the string representation
+        self.assertEqual(str(submit_button.value), "Save")
+
+    def test_sets_form_tag_attribute(self):
+        """Test that form_tag is set to True."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertTrue(form.helper.form_tag)
+
+    def test_sets_label_class_attribute(self):
+        """Test that label_class is set to 'col-md-3'."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertEqual(form.helper.label_class, "col-md-3")
+
+    def test_sets_field_class_attribute(self):
+        """Test that field_class is set to 'col-md-9'."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertEqual(form.helper.field_class, "col-md-9")
+
+    def test_sets_label_size_attribute(self):
+        """Test that label_size is set to ' col-md-offset-3'."""
+        form = CrispyLayoutFormWithMixin()
+
+        self.assertEqual(form.helper.label_size, " col-md-offset-3")
+
+    def test_calls_super_init(self):
+        """Test that super().__init__() is called to initialize parent classes."""
+        # Create the form and verify parent initialization was successful
+        form = CrispyLayoutFormWithMixin()
+
+        # Verify that parent __init__ was called by checking form fields are initialized
+        self.assertIn("name", form.fields)
+        # Verify the field is properly initialized with Django form attributes
+        self.assertIsInstance(form.fields["name"], forms.CharField)
+
+    def test_accepts_args_and_kwargs(self):
+        """Test that mixin properly passes args and kwargs to parent."""
+        data = {"name": "Test Name"}
+        form = CrispyLayoutFormWithMixin(data=data)
+
+        # Verify form works correctly with passed data
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["name"], "Test Name")
+
+    def test_multiple_instantiation(self):
+        """Test that multiple form instances have independent helpers."""
+        form1 = CrispyLayoutFormWithMixin()
+        form2 = CrispyLayoutFormWithMixin()
+
+        # Verify each has its own helper instance
+        self.assertIsNot(form1.helper, form2.helper)
+
+    def test_form_renders_with_crispy_helper(self):
+        """Test that form can be rendered with crispy helper."""
+        form = CrispyLayoutFormWithMixin()
+
+        # Should not raise an exception
+        form_html = str(form)
+        self.assertIsInstance(form_html, str)

--- a/tests/view_layer/test_htmx_response_mixin.py
+++ b/tests/view_layer/test_htmx_response_mixin.py
@@ -1,6 +1,8 @@
+import json
 from typing import ClassVar
 
 from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse
 from django.test import TestCase
 from django.views import generic
 
@@ -9,14 +11,69 @@ from ambient_toolbox.view_layer.htmx_mixins import HtmxResponseMixin
 
 
 class HtmxResponseMixinTest(RequestProviderMixin, TestCase):
+    """Test suite for HtmxResponseMixin with 100% branch coverage."""
+
     class ViewTestView(HtmxResponseMixin, generic.View):
         hx_redirect_url = "https://my-url.com"
         hx_trigger = "myEvent"
 
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
     class TestViewWithTriggerDict(HtmxResponseMixin, generic.View):
         hx_trigger: ClassVar = {"myEvent": None}
 
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
+    class TestViewWithComplexTriggerDict(HtmxResponseMixin, generic.View):
+        hx_trigger: ClassVar = {"event1": "value1", "event2": {"key": "value"}}
+
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
+    class TestViewNoHeaders(HtmxResponseMixin, generic.View):
+        # Both hx_redirect_url and hx_trigger are None by default
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
+    class TestViewOnlyRedirect(HtmxResponseMixin, generic.View):
+        hx_redirect_url = "https://redirect-only.com"
+        # hx_trigger is None
+
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
+    class TestViewOnlyTrigger(HtmxResponseMixin, generic.View):
+        # hx_redirect_url is None
+        hx_trigger = "triggerOnly"
+
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
+    class TestViewDynamicRedirect(HtmxResponseMixin, generic.View):
+        def get_hx_redirect_url(self):
+            return "https://dynamic-redirect.com"
+
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
+    class TestViewDynamicTrigger(HtmxResponseMixin, generic.View):
+        def get_hx_trigger(self):
+            return "dynamicTrigger"
+
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
+    class TestViewDynamicTriggerDict(HtmxResponseMixin, generic.View):
+        def get_hx_trigger(self):
+            return {"dynamicEvent": "dynamicValue"}
+
+        def get(self, request, *args, **kwargs):
+            return HttpResponse(status=200)
+
     def test_dispatch_functional(self):
+        """Test dispatch with both redirect_url and trigger (string) set."""
         view = self.ViewTestView()
 
         response = view.dispatch(request=self.get_request(user=AnonymousUser()))
@@ -28,6 +85,7 @@ class HtmxResponseMixinTest(RequestProviderMixin, TestCase):
         self.assertEqual(response["HX-Trigger"], "myEvent")
 
     def test_dispatch_trigger_with_dict(self):
+        """Test dispatch with trigger as a dict (with None value)."""
         view = self.TestViewWithTriggerDict()
 
         response = view.dispatch(request=self.get_request(user=AnonymousUser()))
@@ -35,12 +93,102 @@ class HtmxResponseMixinTest(RequestProviderMixin, TestCase):
         self.assertIn("HX-Trigger", response)
         self.assertEqual(response["HX-Trigger"], '{"myEvent": null}')
 
+    def test_dispatch_trigger_with_complex_dict(self):
+        """Test dispatch with trigger as a dict with complex values."""
+        view = self.TestViewWithComplexTriggerDict()
+
+        response = view.dispatch(request=self.get_request(user=AnonymousUser()))
+
+        self.assertIn("HX-Trigger", response)
+        # JSON should properly serialize the dict
+        trigger_data = json.loads(response["HX-Trigger"])
+        self.assertEqual(trigger_data["event1"], "value1")
+        self.assertEqual(trigger_data["event2"]["key"], "value")
+
+    def test_dispatch_no_headers(self):
+        """Test dispatch when both redirect_url and trigger are None."""
+        view = self.TestViewNoHeaders()
+
+        response = view.dispatch(request=self.get_request(user=AnonymousUser()))
+
+        # Verify headers are not set
+        self.assertNotIn("HX-Redirect", response)
+        self.assertNotIn("HX-Trigger", response)
+        self.assertEqual(response.status_code, 200)
+
+    def test_dispatch_only_redirect(self):
+        """Test dispatch with only redirect_url set (no trigger)."""
+        view = self.TestViewOnlyRedirect()
+
+        response = view.dispatch(request=self.get_request(user=AnonymousUser()))
+
+        self.assertIn("HX-Redirect", response)
+        self.assertEqual(response["HX-Redirect"], "https://redirect-only.com")
+        self.assertNotIn("HX-Trigger", response)
+
+    def test_dispatch_only_trigger(self):
+        """Test dispatch with only trigger set (no redirect_url)."""
+        view = self.TestViewOnlyTrigger()
+
+        response = view.dispatch(request=self.get_request(user=AnonymousUser()))
+
+        self.assertNotIn("HX-Redirect", response)
+        self.assertIn("HX-Trigger", response)
+        self.assertEqual(response["HX-Trigger"], "triggerOnly")
+
     def test_get_hx_redirect_url_regular(self):
+        """Test get_hx_redirect_url returns class attribute value."""
         view = self.ViewTestView()
 
         self.assertEqual(view.get_hx_redirect_url(), "https://my-url.com")
 
+    def test_get_hx_redirect_url_none(self):
+        """Test get_hx_redirect_url returns None when not set."""
+        view = self.TestViewNoHeaders()
+
+        self.assertIsNone(view.get_hx_redirect_url())
+
     def test_get_hx_trigger_regular(self):
+        """Test get_hx_trigger returns class attribute value (string)."""
         view = self.ViewTestView()
 
         self.assertEqual(view.get_hx_trigger(), "myEvent")
+
+    def test_get_hx_trigger_dict(self):
+        """Test get_hx_trigger returns class attribute value (dict)."""
+        view = self.TestViewWithTriggerDict()
+
+        self.assertEqual(view.get_hx_trigger(), {"myEvent": None})
+
+    def test_get_hx_trigger_none(self):
+        """Test get_hx_trigger returns None when not set."""
+        view = self.TestViewNoHeaders()
+
+        self.assertIsNone(view.get_hx_trigger())
+
+    def test_dynamic_redirect_url(self):
+        """Test dispatch with overridden get_hx_redirect_url method."""
+        view = self.TestViewDynamicRedirect()
+
+        response = view.dispatch(request=self.get_request(user=AnonymousUser()))
+
+        self.assertIn("HX-Redirect", response)
+        self.assertEqual(response["HX-Redirect"], "https://dynamic-redirect.com")
+
+    def test_dynamic_trigger_string(self):
+        """Test dispatch with overridden get_hx_trigger method returning string."""
+        view = self.TestViewDynamicTrigger()
+
+        response = view.dispatch(request=self.get_request(user=AnonymousUser()))
+
+        self.assertIn("HX-Trigger", response)
+        self.assertEqual(response["HX-Trigger"], "dynamicTrigger")
+
+    def test_dynamic_trigger_dict(self):
+        """Test dispatch with overridden get_hx_trigger method returning dict."""
+        view = self.TestViewDynamicTriggerDict()
+
+        response = view.dispatch(request=self.get_request(user=AnonymousUser()))
+
+        self.assertIn("HX-Trigger", response)
+        self.assertEqual(response["HX-Trigger"], '{"dynamicEvent": "dynamicValue"}')


### PR DESCRIPTION
…0% branch coverage

- Created new test_form_mixins.py with 13 tests for CrispyLayoutFormMixin
- Enhanced test_htmx_response_mixin.py from 6 to 14 tests for HtmxResponseMixin
- All tests follow pytest conventions and repo testing patterns
- Achieved 100% branch coverage for both modules
- All pre-commit hooks pass