### PR TITLE
Docs: Update usage instructions for `block_external_requests` fixture

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**12.6.6** (2025-12-17)
+  * Update docs on how to use `block_external_requests` fixture
+
 **12.6.5** (2025-12-11)
   * Maintenance updates via ambient-package-update
 

--- a/ambient_toolbox/__init__.py
+++ b/ambient_toolbox/__init__.py
@@ -1,3 +1,3 @@
 """Python toolbox of Ambient Digital containing an abundance of useful tools and gadgets."""
 
-__version__ = "12.6.5"
+__version__ = "12.6.6"

--- a/docs/features/tests.md
+++ b/docs/features/tests.md
@@ -13,17 +13,19 @@ while allowing localhost connections.
 For pytest-based tests, use the `block_external_requests` fixture. This fixture patches `socket.getaddrinfo` to only
 allow connections to localhost addresses (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`).
 
-If you want to apply it to all tests in your suite automatically, create a wrapper fixture in your `conftest.py`:
+If you want to apply it to all tests in your suite automatically, register the helper plugin and create a wrapper
+fixture in your `conftest.py`:
 
 ```python
-from ambient_toolbox.tests.fixtures.block_external_requests import (
-    block_external_requests as _block_external_requests,
-)
 import pytest
+
+pytest_plugins = [
+    "ambient_toolbox.tests.fixtures.block_external_requests",
+]
 
 
 @pytest.fixture(autouse=True)
-def block_external_requests_autouse(_block_external_requests):
+def block_external_requests_autouse(block_external_requests):
     """Auto-apply external request blocking to all tests."""
     pass
 ```
@@ -158,6 +160,7 @@ You can either check for a full message or just for a partial one.
 ````python
 from django.test import TestCase
 from ambient_toolbox.tests.mixins import DjangoMessagingFrameworkTestMixin
+
 
 class MyViewTest(DjangoMessagingFrameworkTestMixin, TestCase):
 


### PR DESCRIPTION
- Add plugin registration step to `block_external_requests` docs
- Increment version to 12.6.6 in `__init__.py` and `CHANGES.md`

---

Hey @GitRon,

I used the block_external_requests fixture in my app, but it did not work the way the docs explained :slightly_frowning_face: 

Instead, I had to define it as a plugin, hence this fix.