### PR TITLE
Fix Sentry reporter configuration docs

### DIFF
--- a/docs/features/sentry.md
+++ b/docs/features/sentry.md
@@ -90,7 +90,7 @@ Q_CLUSTER = {
     "queue_limit": 50,
     "bold": True,
     "orm": "default",
-    "reporter": {"ambient-djangoq2-sentry": {"dsn": SENTRY_DSN}}
+    "reporter": {"ambient-djangoq2-sentry": {"dsn": SENTRY_DSN}},
 }
 ```
 


### PR DESCRIPTION
Fix docs to use correct sentry reporter settings (string instead of class)

(sorry, made a mistake writing the docs and used the debug settings instead of the ones when installing it as a package)