### PR TITLE
Defer httpx import in validate_gitlab_coverage command (v12.10.3)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**12.10.3** (2026-05-22)
+* Fixed `validate_gitlab_coverage` management command triggering an `httpx` ImportError on command discovery when the optional `gitlab-coverage` extra was not installed
+
 **12.10.2** (2026-05-11)
 * Fixed `ContextVar` leak in `CurrentRequestMiddleware` when `get_response` raises an exception
 

--- a/ambient_toolbox/__init__.py
+++ b/ambient_toolbox/__init__.py
@@ -1,3 +1,3 @@
 """Python toolbox of Ambient Digital containing an abundance of useful tools and gadgets."""
 
-__version__ = "12.10.2"
+__version__ = "12.10.3"

--- a/ambient_toolbox/management/commands/validate_gitlab_coverage.py
+++ b/ambient_toolbox/management/commands/validate_gitlab_coverage.py
@@ -1,6 +1,4 @@
-from django.core.management.base import BaseCommand
-
-from ambient_toolbox.gitlab.coverage import CoverageService
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
@@ -12,5 +10,17 @@ class Command(BaseCommand):
     help = "Validates that test coverage has not dropped relative to the default branch (GitLab only)."
 
     def handle(self, *args, **options):
+        # Imports are deferred so projects without the optional `gitlab-coverage` extra
+        # can load the management command list without an httpx ImportError.
+        try:
+            import httpx  # noqa: F401, PLC0415
+        except ImportError as e:
+            raise CommandError(
+                "The 'validate_gitlab_coverage' command requires the optional 'gitlab-coverage' extra. "
+                "Install it with: pip install ambient-toolbox[gitlab-coverage]"
+            ) from e
+
+        from ambient_toolbox.gitlab.coverage import CoverageService  # noqa: PLC0415
+
         service = CoverageService()
         return service.process()

--- a/tests/management/commands/test_validate_gitlab_coverage.py
+++ b/tests/management/commands/test_validate_gitlab_coverage.py
@@ -1,13 +1,15 @@
+import sys
 from unittest import mock
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import SimpleTestCase
 
 
 class ValidateGitlabCoverageCommandTest(SimpleTestCase):
     """Test cases for validate_gitlab_coverage management command."""
 
-    @mock.patch("ambient_toolbox.management.commands.validate_gitlab_coverage.CoverageService")
+    @mock.patch("ambient_toolbox.gitlab.coverage.CoverageService")
     def test_management_command_calls_coverage_service(self, mock_coverage_service_class):
         """Test that the command calls CoverageService.process()."""
         mock_service_instance = mock.MagicMock()
@@ -19,7 +21,7 @@ class ValidateGitlabCoverageCommandTest(SimpleTestCase):
         mock_coverage_service_class.assert_called_once_with()
         mock_service_instance.process.assert_called_once_with()
 
-    @mock.patch("ambient_toolbox.management.commands.validate_gitlab_coverage.CoverageService")
+    @mock.patch("ambient_toolbox.gitlab.coverage.CoverageService")
     def test_management_command_returns_process_result(self, mock_coverage_service_class):
         """Test that the command returns the result from process()."""
         mock_service_instance = mock.MagicMock()
@@ -31,7 +33,7 @@ class ValidateGitlabCoverageCommandTest(SimpleTestCase):
         self.assertEqual(result, "some_value")
         mock_service_instance.process.assert_called_once_with()
 
-    @mock.patch("ambient_toolbox.management.commands.validate_gitlab_coverage.CoverageService")
+    @mock.patch("ambient_toolbox.gitlab.coverage.CoverageService")
     def test_management_command_propagates_exceptions(self, mock_coverage_service_class):
         """Test that exceptions from CoverageService.process() are propagated."""
         mock_service_instance = mock.MagicMock()
@@ -43,3 +45,12 @@ class ValidateGitlabCoverageCommandTest(SimpleTestCase):
 
         self.assertEqual(str(cm.exception), "Coverage validation failed")
         mock_service_instance.process.assert_called_once_with()
+
+    def test_management_command_raises_command_error_when_httpx_missing(self):
+        """When the optional `gitlab-coverage` extra is not installed, the command should raise
+        a helpful CommandError instead of leaking the raw ImportError."""
+        with mock.patch.dict(sys.modules, {"httpx": None}):
+            with self.assertRaises(CommandError) as cm:
+                call_command("validate_gitlab_coverage")
+
+        self.assertIn("gitlab-coverage", str(cm.exception))


### PR DESCRIPTION
The management command imported CoverageService at module level, which in turn imported httpx. Projects that did not install the optional gitlab-coverage extra hit an ImportError during command discovery ("Error fetching command 'validate_gitlab_coverage': No module named 'httpx'"). The import is now deferred to handle() with an explicit httpx probe that raises a clear CommandError pointing at the extra.